### PR TITLE
Updated DataFrame vs Buffer blogpots & added new alias Methods

### DIFF
--- a/src/Containers-Buffer-Tests/CTFIFOBufferTest.class.st
+++ b/src/Containers-Buffer-Tests/CTFIFOBufferTest.class.st
@@ -17,6 +17,26 @@ CTFIFOBufferTest >> setUp [
 ]
 
 { #category : 'tests' }
+CTFIFOBufferTest >> testAddAlias [
+
+	buffer add: 'first'.
+	self assert: buffer size equals: 1.
+	self assert: buffer peek equals: 'first'.
+	
+	buffer add: 'second'.
+	self assert: buffer size equals: 2
+]
+
+{ #category : 'tests' }
+CTFIFOBufferTest >> testAddAllAlias [
+
+	| result |
+	result := buffer addAll: #( 'a' 'b' 'c' ).
+	self assert: buffer size equals: 3.
+	self assert: buffer isFull
+]
+
+{ #category : 'tests' }
 CTFIFOBufferTest >> testChatMessageQueue [
 
 	| chatQueue displayedMessages |

--- a/src/Containers-Buffer/CTAbstractBuffer.class.st
+++ b/src/Containers-Buffer/CTAbstractBuffer.class.st
@@ -25,13 +25,24 @@ CTAbstractBuffer class >> new [
 
 { #category : 'instance creation' }
 CTAbstractBuffer class >> new: anInteger [
-
 	"Create a new buffer with the specified capacity"
 
 	anInteger < 1 ifTrue: [ self error: 'Capacity must be positive' ].
 	^ self basicNew
-		initializeWithCapacity: anInteger;
-		yourself
+		  setupWithCapacity: anInteger;
+		  yourself
+]
+
+{ #category : 'adding' }
+CTAbstractBuffer >> add: anObject [
+
+	^ self push: anObject 
+]
+
+{ #category : 'adding' }
+CTAbstractBuffer >> addAll: aCollection [
+
+	^ self pushAll: aCollection 
 ]
 
 { #category : 'accessing' }
@@ -66,23 +77,6 @@ CTAbstractBuffer >> do: aBlock [
 CTAbstractBuffer >> elements [
 
 	^ elements
-]
-
-{ #category : 'initialization' }
-CTAbstractBuffer >> initialize [
-
-	super initialize.
-	self initializeWithCapacity: 10
-]
-
-{ #category : 'private' }
-CTAbstractBuffer >> initializeWithCapacity: anInteger [
-
-	capacity := anInteger.
-	elements := Array new: capacity.
-	readIndex := 1.
-	writeIndex := 1.
-	currentSize := 0
 ]
 
 { #category : 'testing' }
@@ -177,6 +171,16 @@ CTAbstractBuffer >> removeAll [
 	"Remove all elements from the buffer"
 	
 	1 to: capacity do: [ :i | elements at: i put: nil ].
+	readIndex := 1.
+	writeIndex := 1.
+	currentSize := 0
+]
+
+{ #category : 'private' }
+CTAbstractBuffer >> setupWithCapacity: anInteger [
+
+	capacity := anInteger.
+	elements := Array new: capacity.
 	readIndex := 1.
 	writeIndex := 1.
 	currentSize := 0


### PR DESCRIPTION
**Changes**:
- Added new alias methods `add:` & `addAll:` for `push:` & `pushAll:` 
- Added tests for alias
- Modified initialisation method for buffer
- Improved & fixed issue in DataFrame vs Buffer blopost & update the results accordingly for the benchmark comparison